### PR TITLE
fix: pin haskell image to v8.10.7-3.6.2.0-3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/blinklabs-io/haskell:8.10.7-3.6.2.0 as cardano-db-sync-build
+FROM ghcr.io/blinklabs-io/haskell:8.10.7-3.6.2.0-3 as cardano-db-sync-build
 RUN apt-get update && apt-get install -y libpq-dev
 # Install cardano-db-sync
 ARG DBSYNC_VERSION=13.1.0.2


### PR DESCRIPTION
Replaces #27 
Closes #26 