### PR TITLE
feat: cardano-db-sync 13.6.0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM ghcr.io/blinklabs-io/haskell:9.6.3-3.10.2.0-2 AS cardano-db-sync-build
 RUN apt-get update && apt-get install -y libpq-dev
 # Install cardano-db-sync
-ARG DBSYNC_VERSION=13.6.0.5
+ARG DBSYNC_VERSION=13.6.0.7
 ENV DBSYNC_VERSION=${DBSYNC_VERSION}
-ARG DBSYNC_REF=tags/13.6.0.5
+ARG DBSYNC_REF=tags/13.6.0.7
 ENV DBSYNC_REF=${DBSYNC_REF}
-ARG DBTOOL_VERSION=13.6.0.5
+ARG DBTOOL_VERSION=13.6.0.7
 ENV DBTOOL_VERSION=${DBTOOL_VERSION}
 RUN echo "Building ${DBSYNC_REF}..." \
     && echo ${DBSYNC_REF} > /CARDANO_DB_SYNC_REF \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `cardano-db-sync` to 13.6.0.7 in the Docker build, with matching `db-tool`. Pulls in the latest upstream fixes.

- **Dependencies**
  - `cardano-db-sync`: 13.6.0.5 → 13.6.0.7 (`DBSYNC_VERSION`, `DBSYNC_REF`)
  - `db-tool`: 13.6.0.5 → 13.6.0.7

<sup>Written for commit 773f1938a4ce3f9c750969df053b36dff0d1c019. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

