### PR TITLE
feat: cardano-db-sync 13.7.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/blinklabs-io/haskell:9.6.3-3.10.2.0-2 AS cardano-db-sync-build
+FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3 AS cardano-db-sync-build
 RUN apt-get update && apt-get install -y libpq-dev
 # Install cardano-db-sync
 ARG DBSYNC_VERSION=13.7.0.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM ghcr.io/blinklabs-io/haskell:9.6.3-3.10.2.0-2 AS cardano-db-sync-build
 RUN apt-get update && apt-get install -y libpq-dev
 # Install cardano-db-sync
-ARG DBSYNC_VERSION=13.6.0.7
+ARG DBSYNC_VERSION=13.7.0.4
 ENV DBSYNC_VERSION=${DBSYNC_VERSION}
-ARG DBSYNC_REF=tags/13.6.0.7
+ARG DBSYNC_REF=tags/13.7.0.4
 ENV DBSYNC_REF=${DBSYNC_REF}
-ARG DBTOOL_VERSION=13.6.0.7
+ARG DBTOOL_VERSION=13.7.0.4
 ENV DBTOOL_VERSION=${DBTOOL_VERSION}
 RUN echo "Building ${DBSYNC_REF}..." \
     && echo ${DBSYNC_REF} > /CARDANO_DB_SYNC_REF \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Docker build to `cardano-db-sync` 13.7.0.4 and update base image to `ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3` to match the latest upstream release.
Updated Dockerfile ARGs `DBSYNC_VERSION`, `DBSYNC_REF`, and `DBTOOL_VERSION` to 13.7.0.4.

<sup>Written for commit 0780b672d1abfd5e9cbc2852958e415a15bba086. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cardano DB Sync to version 13.7.0.4 (from 13.6.0.7)
  * Updated DB Tool to version 13.7.0.4 (from 13.6.0.7)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->