### PR TITLE
fix: Add liburing2 dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update -y && \
     libsystemd0 \
     libssl3 \
     libtinfo6 \
+    liburing2 \
     llvm-14-runtime \
     pkg-config \
     postgresql-client \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `liburing2` to the Docker image to satisfy the io_uring runtime dependency and prevent startup failures. Ensures the app boots correctly on Debian/Ubuntu-based containers.

<sup>Written for commit 8968a1688b4c5e868afe34f3276eb768be0d2d2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build configuration to include an additional system dependency for enhanced runtime compatibility and performance in cardano-db-sync containerized deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->