### PR TITLE
fix: Add missing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,12 @@ RUN apt-get update -y && \
     curl \
     libffi8 \
     libgmp10 \
+    liblmdb0 \
     libncursesw5 \
     libnuma1 \
-    libsystemd0 \
+    libsnappy1v5 \
     libssl3 \
+    libsystemd0 \
     libtinfo6 \
     liburing2 \
     llvm-14-runtime \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add missing runtime libs to the Docker image to prevent startup/linker errors when using LMDB and Snappy features. Adds `liblmdb0` and `libsnappy1v5`, and ensures `libsystemd0` remains installed.

<sup>Written for commit 5133a306334254e801658d2b635e611ff8cbed19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration with additional runtime support libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->