### PR TITLE
fix: Add missing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,12 @@ RUN apt-get update -y && \
     curl \
     libffi8 \
     libgmp10 \
+    liblmdb0 \
     libncursesw5 \
     libnuma1 \
-    libsystemd0 \
+    libsnappy1v5 \
     libssl3 \
+    libsystemd0 \
     libtinfo6 \
     liburing2 \
     llvm-14-runtime \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add missing runtime libraries to the Docker image to prevent startup failures due to missing LMDB and Snappy dependencies.

- **Bug Fixes**
  - Install `liblmdb0` and `libsnappy1v5` in the base image.

<sup>Written for commit 81e246d9f73e1186faf92aad32ef9bb8a6e19790. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

