### PR TITLE
feat: cardano-db-sync 13.7.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3 AS cardano-db-sync-build
 RUN apt-get update && apt-get install -y libpq-dev
 # Install cardano-db-sync
-ARG DBSYNC_VERSION=13.7.0.4
+ARG DBSYNC_VERSION=13.7.0.5
 ENV DBSYNC_VERSION=${DBSYNC_VERSION}
-ARG DBSYNC_REF=tags/13.7.0.4
+ARG DBSYNC_REF=tags/13.7.0.5
 ENV DBSYNC_REF=${DBSYNC_REF}
-ARG DBTOOL_VERSION=13.7.0.4
+ARG DBTOOL_VERSION=13.7.0.5
 ENV DBTOOL_VERSION=${DBTOOL_VERSION}
 RUN echo "Building ${DBSYNC_REF}..." \
     && echo ${DBSYNC_REF} > /CARDANO_DB_SYNC_REF \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `cardano-db-sync` to 13.7.0.5 in the Docker build to pull the latest tag and fixes.

- Updated `DBSYNC_VERSION`, `DBSYNC_REF`, and `DBTOOL_VERSION` to 13.7.0.5.

<sup>Written for commit adeeab1bb80f94450d88af1c3d0c0458197774ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

